### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/rospy2/__init__.py
+++ b/src/rospy2/__init__.py
@@ -12,7 +12,7 @@ import random
 import rclpy
 import rclpy.logging
 import rclpy.qos
-import rclpy.qos_event
+import rclpy.event_handler
 import sys
 import time
 import types


### PR DESCRIPTION
Fixes:
```
/opt/ros/iron/lib/python3.10/site-packages/rclpy/qos_event.py:19: UserWarning: importing 'qos_event' is deprecated; import 'event_handler' instead
```

Verified for all [active](https://dlu.github.io/ros_clock/index.html) ROS2 distros